### PR TITLE
Fix URLs when ampersand in query string

### DIFF
--- a/node_modules/primo-explore-external-search/js/external-search.module.js
+++ b/node_modules/primo-explore-external-search/js/external-search.module.js
@@ -44,7 +44,7 @@ angular
         this.$onInit = function(){
           {
             $scope.targets = searchTargets
-            let query = $location.search().query
+            let query = $location.search().query.replace('&','%26')
             let filter = $location.search().pfilter
             $scope.queries = Array.isArray(query) ? query : query ? [query] : false
             $scope.filters = Array.isArray(filter) ? filter : filter ? [filter] : false


### PR DESCRIPTION
Reported in [OPS-3911](https://ucsb-atlas.atlassian.net/browse/OPS-3911)

Issue caused by ampersand in query interpreted as parameter separator in URL.
![image](https://user-images.githubusercontent.com/82611274/232087053-2f19cc11-bbc1-4889-ba07-304309c76367.png)